### PR TITLE
Add 'head' link to always download the latest release.

### DIFF
--- a/kubescape.rb
+++ b/kubescape.rb
@@ -1,6 +1,7 @@
 class Kubescape < Formula
   desc "Kubernetes testing according to Hardening Guidance by NSA and CISA"
   homepage "https://github.com/armosec/kubescape"
+  head "https://github.com/armosec/kubescape/releases/latest/download/kubescape-macos-latest"
   url "https://github.com/armosec/kubescape/releases/download/v1.0.132/kubescape-macos-latest"
   sha256 "7c55d8e140d511b3f9a22b2a81179f89899e928d16219bb7833d5f0ee8f5c4df"
   license "Apache-2.0"


### PR DESCRIPTION
The command `brew install kubescape --HEAD` will always install the latest version without need to always update the version in the formula.